### PR TITLE
Gzip decompression for the xml rpc client

### DIFF
--- a/lib/xmlrpc/client.rb
+++ b/lib/xmlrpc/client.rb
@@ -573,7 +573,10 @@ module XMLRPC
           WEBrick::Cookie.new(cookie.name, cookie.value).to_s
         end.join("; ")
       end
-
+      ce = resp["Content-Encoding"]
+      if ce.eql?"gzip"
+        data = Zlib::GzipReader.new(StringIO.new(data)).read
+      end
       return data
     end
 


### PR DESCRIPTION
I'm using a xmlrpc client which could benefit from gzip compression. I've added a few lines to the xmlrpc client to make this possible.
