### PR TITLE
Bug fix: :!= symbol and calls to #!= makes the parser send a syntax error message

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -955,6 +955,7 @@ op		: '|'		{ $$ = '|'; }
 		| tGEQ		{ $$ = tGEQ; }
 		| '<'		{ $$ = '<'; }
 		| tLEQ		{ $$ = tLEQ; }
+		| tNEQ		{ $$ = tNEQ; }
 		| tLSHFT	{ $$ = tLSHFT; }
 		| tRSHFT	{ $$ = tRSHFT; }
 		| '+'		{ $$ = '+'; }


### PR DESCRIPTION
This is affecting any software relying on dynamically sending the message !=, like puppet < 2.7's augeas provider.

How to reproduce the bug:

ruby -e 'puts 8.!= 5'
ruby -e 'puts :!='

That should print

true
!=

but prints a syntax error message instead.
